### PR TITLE
feat: add API tests for tmid in chat.postMessage

### DIFF
--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -689,6 +689,108 @@ describe('[Chat]', () => {
 		});
 	});
 
+	describe('Threaded replies with tmid', () => {
+		it('should send a threaded reply to a message in a channel using tmid with channel name', async () => {
+			const channelName = `chat-api-tmid-channel-test-${Date.now()}`;
+			let testChannelResponse;
+			try {
+				// 1. Create a new public channel for testing
+				testChannelResponse = await createRoom({ type: 'c', name: channelName });
+				expect(testChannelResponse.body.success).to.be.true;
+				const testChannel = testChannelResponse.body.channel;
+
+				// 2. Post an initial message to this channel
+				const initialMessagePayload = {
+					channel: `#${channelName}`, // Using channel name
+					text: 'Initial message for tmid test',
+				};
+				const initialMessageResponse = await request.post(api('chat.postMessage')).set(credentials).send(initialMessagePayload);
+				expect(initialMessageResponse.status).to.equal(200);
+				expect(initialMessageResponse.body.success).to.be.true;
+				const initialMessageId = initialMessageResponse.body.message._id;
+
+				// 3. Capture the _id of the successfully posted message (done above)
+
+				// 4. Post a second message (the reply) to the same channel, including tmid
+				const replyMessagePayload = {
+					channel: `#${channelName}`, // Using channel name
+					text: 'This is a threaded reply',
+					tmid: initialMessageId,
+				};
+				const replyMessageResponse = await request.post(api('chat.postMessage')).set(credentials).send(replyMessagePayload);
+
+				// 5. Assert that the second message is created successfully
+				expect(replyMessageResponse.status).to.equal(200);
+				expect(replyMessageResponse.body.success).to.be.true;
+
+				// 6. Assert that the response for the second message shows it has the correct tmid
+				expect(replyMessageResponse.body.message.tmid).to.equal(initialMessageId);
+
+				// 7. Optionally, retrieve the second message using chat.getMessage and verify its tmid
+				const getReplyMessageResponse = await request.get(api('chat.getMessage')).set(credentials).query({ msgId: replyMessageResponse.body.message._id });
+				expect(getReplyMessageResponse.status).to.equal(200);
+				expect(getReplyMessageResponse.body.success).to.be.true;
+				expect(getReplyMessageResponse.body.message.tmid).to.equal(initialMessageId);
+
+			} finally {
+				// 8. Clean up by deleting the test channel
+				if (testChannelResponse && testChannelResponse.body.success) {
+					await deleteRoom({ type: 'c', roomId: testChannelResponse.body.channel._id });
+				}
+			}
+		});
+
+		it('should send a threaded reply to a message in a channel using tmid with room ID', async () => {
+			const channelName = `chat-api-tmid-roomid-test-${Date.now()}`;
+			let testRoomResponse;
+			try {
+				// 1. Create a new public channel for testing
+				testRoomResponse = await createRoom({ type: 'c', name: channelName });
+				expect(testRoomResponse.body.success).to.be.true;
+				const testRoomId = testRoomResponse.body.channel._id;
+
+				// 2. Post an initial message to this channel using its roomId
+				const initialMessagePayload = {
+					roomId: testRoomId,
+					text: 'Initial message for tmid with roomId test',
+				};
+				const initialMessageResponse = await request.post(api('chat.postMessage')).set(credentials).send(initialMessagePayload);
+				expect(initialMessageResponse.status).to.equal(200);
+				expect(initialMessageResponse.body.success).to.be.true;
+				const initialMessageId = initialMessageResponse.body.message._id;
+
+				// 3. Capture the _id of the successfully posted message (done above)
+
+				// 4. Post a second message (the reply) to the same room using its roomId, including tmid
+				const replyMessagePayload = {
+					roomId: testRoomId,
+					text: 'This is a threaded reply using roomId',
+					tmid: initialMessageId,
+				};
+				const replyMessageResponse = await request.post(api('chat.postMessage')).set(credentials).send(replyMessagePayload);
+
+				// 5. Assert that the second message is created successfully
+				expect(replyMessageResponse.status).to.equal(200);
+				expect(replyMessageResponse.body.success).to.be.true;
+
+				// 6. Assert that the response for the second message shows it has the correct tmid
+				expect(replyMessageResponse.body.message.tmid).to.equal(initialMessageId);
+
+				// 7. Optionally, retrieve the second message using chat.getMessage and verify its tmid
+				const getReplyMessageResponse = await request.get(api('chat.getMessage')).set(credentials).query({ msgId: replyMessageResponse.body.message._id });
+				expect(getReplyMessageResponse.status).to.equal(200);
+				expect(getReplyMessageResponse.body.success).to.be.true;
+				expect(getReplyMessageResponse.body.message.tmid).to.equal(initialMessageId);
+
+			} finally {
+				// 8. Clean up by deleting the test channel
+				if (testRoomResponse && testRoomResponse.body.success) {
+					await deleteRoom({ type: 'c', roomId: testRoomResponse.body.channel._id });
+				}
+			}
+		});
+	});
+
 	describe('/chat.getMessage', () => {
 		it('should retrieve the message successfully', (done) => {
 			void request


### PR DESCRIPTION
I've added two new API-level end-to-end tests to verify the `tmid` (thread message ID) functionality in the `chat.postMessage` API.

Here's what I did:
1. I reverted a previous E2E test modification in `apps/meteor/tests/e2e/message-actions.spec.ts` as it did not meet your requirement for API-level testing.
2. I located `apps/meteor/tests/end-to-end/api/chat.ts` as the appropriate file for these API tests.
3. I added a new test case: 'should send a threaded reply to a message in a channel using tmid with channel name'. This test:
    - Creates a channel.
    - Posts a root message to the channel using its name.
    - Posts a threaded reply using the root message's ID as `tmid`.
    - Verifies the reply is correctly threaded.
4. I added a second new test case: 'should send a threaded reply to a message in a channel using tmid with room ID'. This test:
    - Creates a channel and gets its room ID.
    - Posts a root message to the channel using its room ID.
    - Posts a threaded reply using the root message's ID as `tmid` and the room ID.
    - Verifies the reply is correctly threaded.

Note:
The execution environment previously faced Node.js version incompatibilities (requires v22.14.0, environment has v18.19.1) when attempting to run full E2E tests. While these new tests are API-level and part of the end-to-end suite, I could not run them to confirm their pass status within this environment. Manual verification in an environment with the correct Node.js version will be required.

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

